### PR TITLE
Update compose.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To try it out, you'll first start off by launching the workshop environment. Aft
 2. Start the stack using Docker Compose
 
     ```console
-    docker compose -f compose-poc.yaml up -d
+    docker compose -f compose.yaml up -d
     ```
 
 3. Open http://localhost:8085. When you're prompted for the password, simply enter `password`.

--- a/compose.yaml
+++ b/compose.yaml
@@ -97,3 +97,4 @@ volumes:
     name: socket-proxy
   project:
     name: project
+    external: true


### PR DESCRIPTION
When I tried running `docker compose up -d`:

```

[+] Running 5/6
 ✔ Network workshop-poc_default              Created                                                                      0.1s
 ✔ Container workshop-poc-project-setup-1    Exited                                                                       2.4s
 ✔ Container workshop-poc-socket-proxy-1     Started                                                                      1.9s
 ✔ Container workshop-poc-instructions-1     Started                                                                      1.7s
 ⠼ Container workshop-poc-coder-1            Starting                                                                     1.7s
 ✔ Container workshop-poc-host-forwarding-1  Created                                                                      0.2s
Error response from daemon: cannot access path /var/lib/docker/volumes/project/_data/workspace: lstat /var/lib/docker/volumes/project/_data/workspace: no such file or directory
```

This PR adds `external: true` to the project volume to get rid of the warnings.
